### PR TITLE
Exibe todos os autores nas referências bibliográficas

### DIFF
--- a/ufbathesis.cls
+++ b/ufbathesis.cls
@@ -108,7 +108,7 @@
             urlcolor=black,
             citecolor=black}
 \fi
-\RequirePackage[alf]{abntex2cite}
+\RequirePackage[alf,abnt-etal-list=0]{abntex2cite}
 \RequirePackage{lastpage}
 \RequirePackage[top=3cm, bottom=2cm, left=3cm, right=2cm]{geometry}
 \RequirePackage{fix-cm}


### PR DESCRIPTION
Anteriormente estava aparecendo "et al." na lista de referências bibliográficas quando a referência possuía muitos autores.